### PR TITLE
Fix Bridge constructor invocation in whc.exe to ensure API key is set properly.

### DIFF
--- a/whc/ConsoleHandler.cs
+++ b/whc/ConsoleHandler.cs
@@ -1036,8 +1036,12 @@ namespace whc
                     {
                         if(WinHueSettings.bridges.BridgeInfo.ContainsKey(WinHueSettings.bridges.DefaultBridge))
                         {
-                            string ip = WinHueSettings.bridges.BridgeInfo[WinHueSettings.bridges.DefaultBridge].ip;
-                            _bridge = new Bridge(IPAddress.Parse(ip), WinHueSettings.bridges.DefaultBridge, WinHueSettings.bridges.BridgeInfo[WinHueSettings.bridges.DefaultBridge].apikey);
+                            string mac = WinHueSettings.bridges.DefaultBridge;
+                            var bridgeSettings = WinHueSettings.bridges.BridgeInfo[mac];
+                            string ip = bridgeSettings.ip;
+                            string name = bridgeSettings.name;
+                            string apiKey = bridgeSettings.apikey;
+                            _bridge = new Bridge(IPAddress.Parse(ip), mac, name, apiKey);
                             if (_bridge != null && _error == false)
                             {
                                 extra = ObjOpts.Parse(extra);


### PR DESCRIPTION
It appears that at some point the number of arguments to the `Bridge` constructor changed and the invocation in ConsoleHandler.cs fell out of sync.  This change adds the `name` argument so that the `apiKey` is in the correct position and communication with the bridge can succeed.